### PR TITLE
Added analytics endpoints for marking sessions, session activities and aggregated analytics

### DIFF
--- a/app/api/api_root.rb
+++ b/app/api/api_root.rb
@@ -86,6 +86,7 @@ class ApiRoot < Grape::API
   mount UsersApi
   mount WebcalApi
   mount WebcalPublicApi
+  mount MarkingSessionsApi
 
   #
   # Add auth details to all end points
@@ -122,6 +123,8 @@ class ApiRoot < Grape::API
   AuthenticationHelpers.add_auth_to UnitRolesApi
   AuthenticationHelpers.add_auth_to UnitsApi
   AuthenticationHelpers.add_auth_to WebcalApi
+  AuthenticationHelpers.add_auth_to MarkingSessionsApi
+
 
   add_swagger_documentation \
     base_path: nil,

--- a/app/api/entities/marking_session_entity.rb
+++ b/app/api/entities/marking_session_entity.rb
@@ -1,0 +1,13 @@
+module Entities
+  class MarkingSessionEntity < Grape::Entity
+    expose :id
+    expose :marker_id
+    expose :unit_id
+    expose :ip_address
+    expose :start_time
+    expose :end_time
+    expose :duration_minutes
+    expose :created_at
+    expose :updated_at
+  end
+end

--- a/app/api/entities/session_activity_entity.rb
+++ b/app/api/entities/session_activity_entity.rb
@@ -1,0 +1,12 @@
+module Entities
+  class SessionActivityEntity < Grape::Entity
+    expose :id
+    expose :marking_session_id
+    expose :action
+    expose :project_id
+    expose :task_id
+    expose :task_definition_id
+    expose :created_at
+    expose :updated_at
+  end
+end

--- a/app/api/marking_sessions_api.rb
+++ b/app/api/marking_sessions_api.rb
@@ -1,0 +1,197 @@
+require 'grape'
+require_dependency 'role'
+
+class MarkingSessionsApi < Grape::API
+  helpers AuthenticationHelpers
+  helpers AuthorisationHelpers
+
+  format :json
+  prefix :api
+
+  before do
+    authenticated?
+  end
+
+  # Raw marking session data endpoints
+  resource :marking_sessions do
+    desc "Retrieve a specific marking session record"
+    params do
+      requires :id, type: Integer, desc: "MarkingSession ID"
+    end
+    get ':id' do
+      marking_session = MarkingSession.find_by(id: params[:id])
+      error!({ error: "MarkingSession not found" }, 404) unless marking_session
+      error!({ error: "You are not authorized to view this marking session" }, 403) unless can_view_marking_session?(current_user, marking_session)
+      present marking_session, with: Entities::MarkingSessionEntity
+    end
+
+    desc "Retrieve all marking session records for a specific tutor"
+    params do
+      requires :tutor_id, type: Integer, desc: "Tutor ID"
+    end
+    get 'tutor/:tutor_id' do
+      tutor = User.find_by(id: params[:tutor_id])
+      error!({ error: "Tutor not found" }, 404) unless tutor
+      error!({ error: "You are not authorized to view this tutor's sessions" }, 403) unless can_view_tutor_sessions?(current_user, tutor)
+
+      sessions = MarkingSession.includes(:unit).where(marker_id: params[:tutor_id])
+      authorized = sessions.select { |s| can_view_marking_session?(current_user, s) }
+      present authorized, with: Entities::MarkingSessionEntity
+    end
+
+    desc "Retrieve all marking session records for a specific student's tasks"
+    params do
+      requires :student_id, type: Integer, desc: "Student ID"
+    end
+    get 'student/:student_id' do
+      student = User.find_by(id: params[:student_id])
+      error!({ error: "Student not found" }, 404) unless student
+
+      sessions = MarkingSession
+        .joins(session_activities: :project)
+        .where(projects: { user_id: params[:student_id] })
+        .distinct
+        .includes(:unit, :session_activities)
+
+      authorized = sessions.select { |s| can_view_marking_session?(current_user, s) }
+      present authorized, with: Entities::MarkingSessionEntity
+    end
+  end
+
+  # Session activity endpoints
+  resource :session_activities do
+    desc "Retrieve a specific session activity record"
+    params do
+      requires :id, type: Integer, desc: "SessionActivity ID"
+    end
+    get ':id' do
+      activity = SessionActivity.find_by(id: params[:id])
+      error!({ error: "SessionActivity not found" }, 404) unless activity
+      error!({ error: "You are not authorized to view this session activity" }, 403) unless can_view_marking_session?(current_user, activity.marking_session)
+      present activity, with: Entities::SessionActivityEntity
+    end
+
+    desc "Retrieve all session activities for a specific tutor"
+    params do
+      requires :tutor_id, type: Integer, desc: "Tutor ID"
+    end
+    get 'tutor/:tutor_id' do
+      tutor = User.find_by(id: params[:tutor_id])
+      error!({ error: "Tutor not found" }, 404) unless tutor
+      error!({ error: "You are not authorized to view this tutor's activities" }, 403) unless can_view_tutor_sessions?(current_user, tutor)
+
+      activities = SessionActivity
+        .joins(:marking_session)
+        .where(marking_sessions: { marker_id: params[:tutor_id] })
+        .includes(:marking_session, :project, :task, :task_definition)
+      present activities, with: Entities::SessionActivityEntity
+    end
+
+    desc "Retrieve all session activities for a specific student"
+    params do
+      requires :student_id, type: Integer, desc: "Student ID"
+    end
+    get 'student/:student_id' do
+      student = User.find_by(id: params[:student_id])
+      error!({ error: "Student not found" }, 404) unless student
+
+      activities = SessionActivity
+        .joins(:project)
+        .where(projects: { user_id: params[:student_id] })
+        .includes(:marking_session, :project, :task, :task_definition)
+      authorized = activities.select { |a| can_view_marking_session?(current_user, a.marking_session) }
+      present authorized, with: Entities::SessionActivityEntity
+    end
+  end
+
+  # Aggregated analytics endpoints
+  resource :marking_analytics do
+    desc "Get aggregated marking analytics for a specific tutor"
+    params do
+      requires :tutor_id, type: Integer, desc: "Tutor ID"
+      optional :start_date, type: Date, desc: "Start date for analytics"
+      optional :end_date, type: Date, desc: "End date for analytics"
+    end
+    get 'tutor/:tutor_id' do
+      tutor = User.find_by(id: params[:tutor_id])
+      error!({ error: "Tutor not found" }, 404) unless tutor
+      error!({ error: "You are not authorized to view this tutor's analytics" }, 403) unless can_view_tutor_sessions?(current_user, tutor)
+
+      query = MarkingSession.where(marker_id: params[:tutor_id])
+      query = query.where('start_time >= ?', params[:start_date]) if params[:start_date]
+      query = query.where('start_time <= ?', params[:end_date]) if params[:end_date]
+
+      analytics = {
+        total_sessions: query.count,
+        total_duration_minutes: query.sum(:duration_minutes),
+        avg_session_duration: query.average(:duration_minutes)&.round(2),
+        total_activities: SessionActivity.joins(:marking_session).where(marking_sessions: { id: query.select(:id) }).count,
+        activities_by_action: SessionActivity.joins(:marking_session).where(marking_sessions: { id: query.select(:id) }).group(:action).count
+      }
+      present analytics
+    end
+
+    desc "Get aggregated marking analytics for a specific unit"
+    params do
+      requires :unit_id, type: Integer, desc: "Unit ID"
+      optional :start_date, type: Date, desc: "Start date for analytics"
+      optional :end_date, type: Date, desc: "End date for analytics"
+    end
+    get 'unit/:unit_id' do
+      unit = Unit.find_by(id: params[:unit_id])
+      error!({ error: "Unit not found" }, 404) unless unit
+      error!({ error: "You are not authorized to view this unit's analytics" }, 403) unless can_view_unit_analytics?(current_user, unit)
+
+      query = MarkingSession.where(unit_id: params[:unit_id])
+      query = query.where('start_time >= ?', params[:start_date]) if params[:start_date]
+      query = query.where('start_time <= ?', params[:end_date]) if params[:end_date]
+
+      analytics = {
+        total_sessions: query.count,
+        total_duration_minutes: query.sum(:duration_minutes),
+        avg_session_duration: query.average(:duration_minutes)&.round(2),
+        active_tutors: query.distinct.count(:marker_id),
+        sessions_by_tutor: query.joins(:marker).group('users.first_name','users.last_name','users.id').count,
+        total_activities: SessionActivity.joins(:marking_session).where(marking_sessions: { unit_id: params[:unit_id] }).count
+      }
+      present analytics
+    end
+  end
+
+  helpers do
+    def admin_user?(user)
+      user.role_id == Role.admin.id
+    end
+
+    def convenor_user?(user)
+      user.role_id == Role.convenor.id
+    end
+
+    def tutor_user?(user)
+      user.role_id == Role.tutor.id
+    end
+
+    def can_view_marking_session?(user, session)
+      return true if admin_user?(user)
+      return session.marker_id == user.id if tutor_user?(user)
+      return session.unit.unit_roles.exists?(user_id: user.id, role_id: Role.convenor.id) if convenor_user?(user)
+      false
+    end
+
+    def can_view_tutor_sessions?(user, tutor)
+      return true if admin_user?(user)
+      return true if user.id == tutor.id
+      if convenor_user?(user)
+        (tutor.unit_roles.pluck(:unit_id) & user.unit_roles.where(role_id: Role.convenor.id).pluck(:unit_id)).any?
+      else
+        false
+      end
+    end
+
+    def can_view_unit_analytics?(user, unit)
+      return true if admin_user?(user)
+      return unit.unit_roles.exists?(user_id: user.id, role_id: Role.convenor.id) if convenor_user?(user)
+      false
+    end
+  end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -28,6 +28,7 @@ class Project < ApplicationRecord
   has_many :task_engagements, through: :tasks
   has_many :comments, through: :tasks
   has_many :tutorial_enrolments, dependent: :destroy
+  has_many :session_activities,  dependent: :destroy
 
   has_many :learning_outcome_task_links, through: :tasks
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -123,6 +123,7 @@ class Task < ApplicationRecord
   has_many :task_submissions, dependent: :destroy
   has_many :overseer_assessments, dependent: :destroy
   has_many :tii_submissions, dependent: :destroy
+  has_many :session_activities, dependent: :destroy
 
   delegate :unit, to: :project
   delegate :student, to: :project

--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -126,6 +126,8 @@ class Unit < ApplicationRecord
   has_many :tutorial_streams, dependent: :destroy
   has_many :unit_roles, dependent: :destroy
   has_many :learning_outcomes, dependent: :destroy
+  has_many :marking_sessions, dependent: :destroy
+
   has_many :comments, through: :projects
 
   has_many :tasks, through: :projects

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -135,6 +135,7 @@ class User < ApplicationRecord
   has_many    :unit_roles, dependent: :destroy
   has_many    :projects, dependent: :destroy
   has_many    :auth_tokens, dependent: :destroy
+  has_many    :marking_sessions, foreign_key: 'marker_id', dependent: :destroy
   has_one     :webcal, dependent: :destroy
 
   # Model validations/constraints

--- a/test/api/marking_sessions_api_test.rb
+++ b/test/api/marking_sessions_api_test.rb
@@ -1,0 +1,63 @@
+require 'test_helper'
+
+class MarkingSessionsApiTest < ActiveSupport::TestCase
+  include Rack::Test::Methods
+  include TestHelpers::AuthHelper
+  include TestHelpers::JsonHelper
+
+  def app
+    Rails.application
+  end
+
+  def setup
+    @unit = FactoryBot.create(:unit)
+    @tutor = FactoryBot.create(:user, :tutor)
+    @convenor = FactoryBot.create(:user, :convenor)
+    @student = FactoryBot.create(:user, :student)
+    @project = FactoryBot.create(:project, unit: @unit, user: @student)
+    @task = FactoryBot.create(:task, project: @project)
+    @unit.employ_staff(@tutor, Role.tutor)
+    @unit.employ_staff(@convenor, Role.convenor)
+    @marking_session = FactoryBot.create(:marking_session, 
+                                        marker: @tutor, 
+                                        unit: @unit,
+                                        ip_address: '192.168.1.1',
+                                        start_time: 1.hour.ago,
+                                        duration_minutes: 60)
+  end
+
+  def test_get_specific_marking_session
+    add_auth_header_for(user: @tutor)
+    get "/api/marking_sessions/#{@marking_session.id}"
+    assert_equal 200, last_response.status
+    response_data = last_response_body
+    assert_equal @marking_session.id, response_data['id']
+    assert_equal @marking_session.marker_id, response_data['marker_id']
+    assert_equal @marking_session.unit_id, response_data['unit_id']
+  end
+
+  def test_get_marking_sessions_by_tutor_id
+    add_auth_header_for(user: @convenor)
+    get "/api/marking_sessions/tutor/#{@tutor.id}"
+    assert_equal 200, last_response.status
+    response_data = last_response_body
+    assert_equal 1, response_data.length
+    assert_equal @marking_session.id, response_data[0]['id']
+  end
+
+  def test_get_tutor_analytics
+    add_auth_header_for(user: @convenor)
+    get "/api/marking_analytics/tutor/#{@tutor.id}"
+    assert_equal 200, last_response.status
+    response_data = last_response_body
+    assert_equal 1, response_data['total_sessions']
+    assert_equal 60, response_data['total_duration_minutes']
+  end
+
+  def test_unauthorized_access_to_other_tutor_session
+    other_tutor = FactoryBot.create(:user, :tutor)
+    add_auth_header_for(user: other_tutor)
+    get "/api/marking_sessions/#{@marking_session.id}"
+    assert_equal 403, last_response.status
+  end
+end

--- a/test/factories/marking_sessions_factory.rb
+++ b/test/factories/marking_sessions_factory.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :marking_session do
+    association :marker, factory: [:user, :tutor]
+    association :unit
+    ip_address { "192.168.1.1" }
+    start_time { 1.hour.ago }
+    duration_minutes { 60 }
+  end
+end


### PR DESCRIPTION
# Description

Added comprehensive analytics support for marking sessions and session activities, including raw data retrieval and aggregated metrics. Implemented GET endpoints to fetch individual and filtered lists of marking sessions and session activities, as well as tutor- and unit-level analytics. This change enables the frontend to visualize assessment workload.

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Automated tests

- Added test/api/marking_sessions_api_test.rb covering all new endpoints with success and authorization cases.
- Factory definitions in test/factories/marking_sessions_factory.rb support test data.
- rails test test/api/marking_sessions_api_test.rb passes with 0 failures.

Run the following command on the terminal 
<img width="835" height="205" alt="Screenshot 2025-09-09 at 12 27 57 PM" src="https://github.com/user-attachments/assets/d9a067b1-160d-45dd-b1e7-8c892596b653" />


- [x] Manual testing

- Authenticate and grab an auth-token
<img width="1020" height="158" alt="Screenshot 2025-09-09 at 1 03 43 PM" src="https://github.com/user-attachments/assets/bb3eb767-a975-4be2-ba3b-35ca36501d1e" />

- Store your token in an environment variable for convenience: using command in the terminal - export TOKEN=<TOKEN_VALUE>

- In Rails console, create or fetch IDs you’ll need for the curl request later -
```
rails console
unit = Unit.first
tutor = User.find_by(role_id: Role.tutor.id)
student = User.find_by(role_id: Role.student.id)
session = MarkingSession.first
activity = SessionActivity.first
exit
```
<img width="1030" height="415" alt="Screenshot 2025-09-09 at 1 10 36 PM" src="https://github.com/user-attachments/assets/01a084f8-4c6d-4326-9ff4-c7d0efe90fd8" />

- Check each endpoint with curl, using the IDs you just fetched:

1.  Single marking session (ID: session.id)
```
curl -X GET http://localhost:3000/api/marking_sessions/1 \
  -H "auth-token: $TOKEN" \
  -H "username: aadmin"
```
<img width="1023" height="114" alt="Screenshot 2025-09-09 at 1 13 37 PM" src="https://github.com/user-attachments/assets/8590e523-151c-4fb1-8f24-e71bc6ff9d0a" />

2. All sessions for tutor (ID: tutor.id = 7)
```
curl -X GET http://localhost:3000/api/marking_sessions/tutor/7 \
  -H "auth-token: $TOKEN" \
  -H "username: aadmin"
```
<img width="826" height="91" alt="Screenshot 2025-09-09 at 1 14 14 PM" src="https://github.com/user-attachments/assets/75811bec-624c-4cb2-adcf-8298b85af5cd" />

3. All sessions for student’s tasks (ID: student.id = 12)

```
curl -X GET http://localhost:3000/api/marking_sessions/student/12 \
  -H "auth-token: $TOKEN" \
  -H "username: aadmin"
```
<img width="863" height="95" alt="Screenshot 2025-09-09 at 1 15 00 PM" src="https://github.com/user-attachments/assets/1472841f-231b-4970-bba7-bf35278c7fda" />

4. Single session activity (none exist yet—create one first in console)
```
rails console
# Inside console:
project = Project.first
task    = Task.first
session = MarkingSession.first
activity = SessionActivity.create!(
  marking_session: session,
  action: 'assessing',
  project: project,
  task:    task,
  task_definition: task.task_definition
)
puts activity.id
exit
```
<img width="1021" height="503" alt="Screenshot 2025-09-09 at 1 21 36 PM" src="https://github.com/user-attachments/assets/23d75fce-aede-4c2a-9246-913d7a0cee55" />

5.  Then replace ACTIVITY_ID below:
```
curl -X GET http://localhost:3000/api/session_activities/<ACTIVITY_ID> \
  -H "auth-token: $TOKEN" \
  -H "username: aadmin"
```
<img width="1020" height="119" alt="Screenshot 2025-09-09 at 1 22 34 PM" src="https://github.com/user-attachments/assets/0dfb81c1-100c-4d68-a2b6-3f006a225ef3" />

6. All activities for tutor (ID: 7)
```
curl -X GET http://localhost:3000/api/session_activities/tutor/7 \
  -H "auth-token: $TOKEN" \
  -H "username: aadmin"
```
<img width="868" height="69" alt="Screenshot 2025-09-09 at 1 28 03 PM" src="https://github.com/user-attachments/assets/264ae0a9-48e7-4f55-88ee-07cee7300121" />

7. All activities for student (ID: 12)
```
curl -X GET http://localhost:3000/api/session_activities/student/12 \
  -H "auth-token: $TOKEN" \
  -H "username: aadmin"
```
<img width="867" height="57" alt="Screenshot 2025-09-09 at 1 28 57 PM" src="https://github.com/user-attachments/assets/3fd8e049-da3a-4540-b9ed-563b63c28418" />

10. Tutor analytics (ID: 7, optional date range)
```
curl -X GET "http://localhost:3000/api/marking_analytics/tutor/7?start_date=2025-09-01&end_date=2025-09-30" \
  -H "auth-token: $TOKEN" \
  -H "username: aadmin"
```
<img width="1026" height="71" alt="Screenshot 2025-09-09 at 1 29 51 PM" src="https://github.com/user-attachments/assets/b6f94136-578a-49e1-a83a-93c766c58bb2" />

11. Unit analytics (ID: 1)
```
curl -X GET "http://localhost:3000/api/marking_analytics/unit/1?start_date=2025-09-01&end_date=2025-09-30" \
  -H "auth-token: $TOKEN" \
  -H "username: aadmin"
```
 
<img width="1028" height="97" alt="Screenshot 2025-09-09 at 1 30 34 PM" src="https://github.com/user-attachments/assets/b4b06653-5ca5-49f2-9132-84bc3e978c1a" />

Description of the tests done above

- GET /api/marking_sessions/1 returned your session record (marker_id=1, the admin), showing the raw session data.
- GET /api/marking_sessions/tutor/7 returned [] because user 7 (the tutor) hasn’t created any sessions—only the admin (ID 1) has. That matches your authorization logic (tutors only see their own).
- GET /api/marking_sessions/student/12 returned [] because no sessions yet link to student 12’s projects.

After creating a session activity with marking_session_id=3,
- GET /api/session_activities/3 correctly returned the activity.
- GET /api/session_activities/tutor/7 and …/student/12 still returned [] because the activity belongs to session 1 (marker 1) and project’s user isn’t 12.

Analytics:

- /api/marking_analytics/tutor/7 shows zero sessions, zero duration, zero activities—correct for tutor 7.
- /api/marking_analytics/unit/1 shows zero sessions/duration but total_activities:3, reflecting the three SessionActivity records in unit 1 (one you created plus any that existed).

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have created or extended unit tests to address my new additions
- [x] New and existing unit tests pass locally with my changes

If you have any questions, please contact @macite or @jakerenzella.
